### PR TITLE
Add web server's hostname and local ip address

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,7 @@ require 'haml'
 require 'i18n'
 require 'i18n/backend/fallbacks'
 require 'rack/contrib'
+require 'socket'
 
 set :haml, escape_html: true
 
@@ -16,6 +17,7 @@ before do
 end
 
 get '/' do
+  @locals = locals
   @envs = envs
   haml :home
 end
@@ -84,4 +86,13 @@ helpers do
   def t *args
     I18n.t *args
   end
+end
+
+def locals
+  hash = {}
+  hash[:locals] = {}
+  hash[:locals]["HOSTNAME"] = Socket.gethostname
+  hash[:locals]["LOCAL_IP"] = IPSocket.getaddress(Socket.gethostname)
+
+  hash
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   service_name: 'ENV Man'
   service_description: 'If you see the environment variables, such as browser version'
+  local_informations: 'Local Informations'
   request_informations: 'Request informations'
   server_informations: 'Server informations'

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -1,5 +1,6 @@
 ja:
   service_name: 'ENVマン'
   service_description: 'ブラウザバージョンなどの環境変数を表示'
+  local_informations: 'ローカル情報'
   request_informations: 'リクエスト送信情報'
   server_informations: 'サーバー情報'

--- a/views/home.haml
+++ b/views/home.haml
@@ -1,3 +1,10 @@
+%h2= "#{t 'local_informations'}"
+%table.table.table-striped.table-hover
+  %tbody
+    - @locals[:locals].each do |key,value|
+      %tr
+        %th{width: 240}= key
+        %td= value
 %h2= "#{t 'request_informations'}"
 %table.table.table-striped.table-hover
   %tbody


### PR DESCRIPTION
#### What's this PR do?
Show web server's hostname and local ip address in html.

#### Any background context you want to provide?
I would like to check these attributes, when web servers behind a load balancer. 

#### Screenshots
**lang_ja**
![env](https://cloud.githubusercontent.com/assets/6873293/12216287/984353cc-b71f-11e5-8132-934669a245e7.png)

**lang_en**
![env-man](https://cloud.githubusercontent.com/assets/6873293/12216285/8fa299ee-b71f-11e5-928c-7cf012b77f5d.png)